### PR TITLE
Fix for dependencies

### DIFF
--- a/requirejs.el
+++ b/requirejs.el
@@ -3,7 +3,7 @@
 ;; Author: Joe Heyming <joeheyming@gmail.com>
 ;; Version: 1.1
 ;; Keywords: javascript, requirejs
-;; Package-Requires: ((js2-mode "20150713")(expand-region "0.10.0")(popup "0.5.3"))
+;; Package-Requires: ((js2-mode "20150713")(expand-region "0.10.0")(popup "0.5.3")(s "1.9.0")(cl-lib "0.5"))
 
 ;;; Commentary:
 ;; This module allows you to:
@@ -29,7 +29,11 @@
 
 ;;; Code:
 
+(require 'js2-mode)
 (require 'popup)
+(require 'expand-region)
+(require 'cl-lib)
+(require 's)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; js2-mode utilities
@@ -183,7 +187,7 @@ the function."
   (forward-char 1))
 
 ;; Define a structure for storing an alias
-(defstruct requirejs-alias
+(cl-defstruct requirejs-alias
   "A rule for a special shim in your requirejs conf"
   label ;; The lookup value of an alias
   variableName ;; The desired variable name to place in a define function.
@@ -402,7 +406,7 @@ returns a non-nil value.")
     ;; (message (format "command = %s" command))
     ;; (message (format "files = %s %s" files (length files)))
     (cond ((equal (car files) "") (error (format "Can't find module: %s" variableName)))
-          ((= (length files) 1) (s-trim (first files)))
+          ((= (length files) 1) (s-trim (cl-first files)))
           ((> (length files) 1) (popup-menu* files :keymap requirejs-popup-keymap))
           )))
 


### PR DESCRIPTION
- Add missing requires(cl-lib, s) to Package-Requires
- Load dependencies(js2-mode, expand-region, s, cl-lib)
- Use cl-lib function/macros instead cl.el ones

I got many byte-compile warnings about this.

```
In requirejs-js2-get-function-call-node:
requirejs.el:133:43:Warning: reference to free variable `js2-NAME'
requirejs.el:135:61:Warning: reference to free variable `js2-CALL'
requirejs.el:186:12:Warning: reference to free variable `requirejs-alias'
requirejs.el:188:3:Warning: reference to free variable `label'
requirejs.el:189:3:Warning: reference to free variable `variableName'
requirejs.el:190:3:Warning: reference to free variable `path'

In requirejs-is-define-call:
requirejs.el:351:28:Warning: reference to free variable `js2-CALL'

In end of data:
requirejs.el:524:1:Warning: the following functions are not known to be defined:
    js2-node-abs-pos, js2-node-len, js2-node-at-point,
    js2-node-parent, js2-node-child-list, js2-ast-root-p,
    js2-node-get-enclosing-scope, js2-function-node-p,
    js2-function-name, js2-var-init-node-p, js2-name-node-name,
    js2-var-init-node-target, js2-visit-ast, js2-node-type,
    js2-get-defining-scope, js2-scope-get-symbol,
    js2-symbol-ast-node, js2-node-root, js2-call-node-lp,
    js2-node-next-sibling, er/mark-outside-pairs, defstruct,
    make-requirejs-alias, requirejs-alias-path,
    requirejs-alias-variableName, js2-indent-region, js2-indent-line,
    s-trim, first, js2-node-abs-end, requirejs-alias-label
```
