### PR TITLE
Declare variable for avoiding using free variable

### DIFF
--- a/requirejs.el
+++ b/requirejs.el
@@ -388,9 +388,9 @@ returns a non-nil value.")
             ))
       
       ;; indent the array node
-      (setq end  (+ 1 (point)))
-      (goto-char (js2-node-abs-pos cur-node))
-      (js2-indent-region (point) end)
+      (let ((end (+ 1 (point))))
+        (goto-char (js2-node-abs-pos cur-node))
+        (js2-indent-region (point) end))
 
       ;; eightify the list manually since the syntax tree spacing may be borked at this point.
       (requirejs-js2-goto-next-node)


### PR DESCRIPTION
I got following byte-compile warning.

```
In requirejs-sort-require-paths:
requirejs.el:391:13:Warning: assignment to free variable `end'
requirejs.el:393:34:Warning: reference to free variable `end'
```
